### PR TITLE
Fix output check functions

### DIFF
--- a/ampscz_asana/lib/qc.py
+++ b/ampscz_asana/lib/qc.py
@@ -116,6 +116,9 @@ def check_when_transferred(expected_mri_path: Union[Path, str]) -> bool:
 
 
 def is_qqc_executed(subject, entry_date) -> bool:
+    if entry_date == '' or pd.isna(entry_date):
+        return False
+
     mri_root = Path('/data/predict1/data_from_nda/MRI_ROOT')
     source_root = mri_root / 'sourcedata'
 
@@ -130,8 +133,8 @@ def is_qqc_executed(subject, entry_date) -> bool:
 
 
 def date_of_zip(subject, entry_date, phoenix_dir):
-    if entry_date == '':
-        return None
+    if entry_date == '' or pd.isna(entry_date):
+        return False
     formatted_entry_date = entry_date.replace("-", "_")
     formatted_entry_date = datetime.strptime(formatted_entry_date, '%Y_%m_%d')
     if 'Pronet' in phoenix_dir:
@@ -164,6 +167,9 @@ def date_of_zip(subject, entry_date, phoenix_dir):
 
 
 def date_of_qqc(subject, entry_date) -> str:
+    if entry_date == '' or pd.isna(entry_date):
+        return ''
+
     mri_root = Path('/data/predict1/data_from_nda/MRI_ROOT')
     source_root = mri_root / 'sourcedata'
     date_numbers_only = re.sub('[-_]', '', entry_date)
@@ -180,6 +186,8 @@ def date_of_qqc(subject, entry_date) -> str:
 
 
 def is_mri_done(subject, entry_date) -> bool:
+    if entry_date == '' or pd.isna(entry_date):
+        return False
     mri_root = Path('/data/predict1/data_from_nda/MRI_ROOT')
     deriv_root = mri_root / 'derivatives' / 'mriqc'
 
@@ -194,6 +202,8 @@ def is_mri_done(subject, entry_date) -> bool:
 
 
 def is_fmriprep_done(subject, entry_date) -> bool:
+    if entry_date == '' or pd.isna(entry_date):
+        return False
     mri_root = Path('/data/predict1/data_from_nda/MRI_ROOT')
     deriv_root = mri_root / 'derivatives' / 'fmriprep'
 
@@ -208,6 +218,8 @@ def is_fmriprep_done(subject, entry_date) -> bool:
 
 
 def is_dwipreproc_done(subject, entry_date) -> bool:
+    if entry_date == '' or pd.isna(entry_date):
+        return False
     mri_root = Path('/data/predict1/data_from_nda/MRI_ROOT')
     deriv_root = mri_root / 'derivatives' / 'dwipreproc'
 

--- a/tests/ampscz_asana/lib/test_qc.py
+++ b/tests/ampscz_asana/lib/test_qc.py
@@ -1,5 +1,6 @@
 from ampscz_asana.lib.qc import date_of_zip, extract_variable_information, extract_missing_data_information, compare_dates, format_days
 from ampscz_asana.lib.qc import get_run_sheet_df, extract_missing_data_info_new
+from ampscz_asana.lib.qc import is_qqc_executed
 import pandas as pd
 from pathlib import Path
 
@@ -81,3 +82,9 @@ def test_extract_missing_data_info_new():
     scan_date = ''
 
     print(extract_missing_data_info_new(subject, phoenix_root, scan_date))
+
+
+def test_is_qqc_executed():
+    subject = 'YA08362'
+    scan_date = ''
+    assert is_qqc_executed(subject, scan_date) == False


### PR DESCRIPTION
Output check functions like `is_qqc_executed` returned `True` even when there was empty `entry_date`. This behavior is fixed by adding `entry_date` conditions at the top of each function.

```sh
cd tests/ampscz_asana/lib
pytest test_qc.py -s -k test_is_qqc_executed
```