### PR TITLE
Add visit status to mri_all_db.csv

### DIFF
--- a/ampscz_asana/lib/qc.py
+++ b/ampscz_asana/lib/qc.py
@@ -1,4 +1,5 @@
-from ampscz_asana.lib.server_scanner import grep_run_sheets
+from ampscz_asana.lib.server_scanner import grep_run_sheets, \
+        return_matching_visit_status
 import re
 import pandas as pd
 import numpy as np
@@ -652,6 +653,12 @@ def get_run_sheet_df(phoenix_dir: Path,
     df['run_sheet_num'] = df.file_path.apply(lambda x: x.name).str.extract(
             '[A-Z]{2}\d{5}\.P\w+\.Run_sheet_\w+_(\d).csv')
     df['subject'] = df.file_loc.str.extract('([A-Z]{2}\d{5})')
+
+    # add visit status
+    subject_visit_dict = return_matching_visit_status(subject_ids.subject)
+    df['visit_status_string'] = df['subject'].map(subject_visit_dict).str[0]
+    df['last_visit_status'] = df['subject'].map(subject_visit_dict).str[1]
+
     # AB00001.Pronet.Run_sheet_mri_1.csv
     df['datatype'] = df.file_path.apply(lambda x: x.name.split('_')[2])
     df['other_files'] = df['file_loc'].apply(lambda x: [x for x in os.listdir(

--- a/tests/ampscz_asana/lib/test_server_scanner.py
+++ b/tests/ampscz_asana/lib/test_server_scanner.py
@@ -1,6 +1,17 @@
-from ampscz_asana.lib.server_scanner import get_most_recent_file
 import re
+import sys
 from pathlib import Path
+
+orig_paths = sys.path
+new_paths = [x for x in orig_paths if 'qqc' not in x]
+CURRENT_FILE = Path(__file__)
+qqc_root = CURRENT_FILE.parent.parent.parent.parent
+sys.path = new_paths + [str(qqc_root)]
+
+from ampscz_asana.lib.server_scanner import get_most_recent_file, \
+        get_subject_timepoint, return_matching_visit_status, \
+        get_visit_df
+import pandas as pd
 from datetime import datetime
 
 
@@ -17,3 +28,32 @@ def test_get_most_recent_file():
         assert str(today.day) in most_recent_file.name
     except:
         assert str(today.day - 1) in most_recent_file.name
+
+
+def test_get_subject_timepoint():
+    visit_df = get_visit_df()
+    subject_id = 'MA13030'
+    visit_stat = get_subject_timepoint(visit_df, subject_id)
+    assert len(visit_stat) == 2
+
+
+def test_return_matching_visit_status():
+    subject_ids = ['MA13030', 'PV18146', 'CM18195']
+    subject_visit_dict = return_matching_visit_status(subject_ids)
+    assert type(subject_visit_dict) == dict
+    assert len(list(subject_visit_dict.values())[0]) == 2
+    assert len(subject_visit_dict) == len(subject_ids)
+
+    print(subject_visit_dict)
+
+    subject_df = pd.DataFrame({'subject': ['MA13030', 'PV18146', 'CM18195']})
+    subject_visit_dict = return_matching_visit_status(subject_df.subject)
+    assert type(subject_visit_dict) == dict
+    assert len(list(subject_visit_dict.values())[0]) == 2
+    assert len(subject_visit_dict) == len(subject_df)
+    subject_df['visit_status_string'] = subject_df['subject'].map(
+            subject_visit_dict).str[0]
+
+    print(subject_df)
+
+

--- a/tests/qqc/qqc/test_dpdash.py
+++ b/tests/qqc/qqc/test_dpdash.py
@@ -164,4 +164,3 @@ def test_find_matching_files_between_BIDS_sessions_missing_input():
             inplace=True)
 
     return json_df_all
-


### PR DESCRIPTION
The data availability chart on DPDash will feature comprehensive details about the specific timepoints for each subject. In this Pull Request (PR), we concentrate on retrieving visit status from the `formsqc` output and integrating it into the `mri_all_db.csv` file. Moreover, we plan to initiate a separate PR dedicated to generating tables on DPDash that will leverage this timepoint information.